### PR TITLE
fixed miscellaneous bugs in cactus code

### DIFF
--- a/src/pages/[...lang]/codes/cactus-code.astro
+++ b/src/pages/[...lang]/codes/cactus-code.astro
@@ -119,18 +119,16 @@ const description = {
     while x!=get_pos_x() or y!=get_pos_y():
         if(get_pos_x()<x):
             move(East)
-        else:
+        elif(get_pos_x()>x):
             move(West)
         if(get_pos_y()<y):
             move(North)
-        else:
+        elif(get_pos_y()>y):
             move(South)
 
 def reverse(dir):
-    if(dir == West): return East
-    if(dir == East): return West
-    if(dir == North): return South
-    if(dir == South): return North`} />
+    opposite = {West:East, East:West, North:South, South:North}
+    return opposite[dir]`} />
             </div>
 
             <div class="mb-12 bg-white dark:bg-gray-800 p-6 rounded-xl border border-gray-200 dark:border-gray-700">
@@ -186,11 +184,11 @@ if(y!=0 and down != None and current<down):
     while x!=get_pos_x() or y!=get_pos_y():
         if(get_pos_x()<x):
             move(East)
-        else:
+        elif(get_pos_x()>x):
             move(West)
         if(get_pos_y()<y):
             move(North)
-        else:
+        elif(get_pos_y()>y):
             move(South)
 
 def plantCactus():
@@ -199,10 +197,8 @@ def plantCactus():
     plant(Entities.Cactus)  
 
 def reverse(dir):
-    if(dir == West): return East
-    if(dir == East): return West
-    if(dir == North): return South
-    if(dir == South): return North
+    opposite = {West:East, East:West, North:South, South:North}
+    return opposite[dir]
 
 def cactusProject(size=3):
     while True:
@@ -256,6 +252,7 @@ def cactusProject(size=3):
                 if(i!=size-1):
                     move(vdir)
                 dir=reverse(dir)
+            vdir = reverse(vdir)
         
         # 3. Harvesting Phase (Once sorted)
         back()

--- a/src/pages/[...lang]/codes/cactus-code.astro
+++ b/src/pages/[...lang]/codes/cactus-code.astro
@@ -252,7 +252,7 @@ def cactusProject(size=3):
                 if(i!=size-1):
                     move(vdir)
                 dir=reverse(dir)
-            vdir = reverse(vdir)
+            vdir=reverse(vdir)
         
         # 3. Harvesting Phase (Once sorted)
         back()


### PR DESCRIPTION
Fixed the following bugs in the code:

1) If one of the coordinates is already correct when the **_back()_** function is called, it is still changed and moved away from, resulting in an unending loop which never arrives at the target destination. This is because as long as one coordinate is different, the condition of the **_while_** loop evaluates to True and enters the body of the loop. Once inside, however, the function always changes **both** coordinates, due to the use of **_if_**/**_else_** instead of **_if_**/**_elif_**, guaranteeing that the drone will always move away from **both** of the current **_x_** and **_y_** coordinates. Replacing the **_else_** with an **_elif_** check which prevents changing the coordinate if it is already correct fixes the issue. Currently the function only works if the final step of the function needs to change both the row and column at the same time.

2) The **_reverse(dir)_** function, defined as:
```
def reverse(dir):
    if(dir == West): return East
    if(dir == East): return West
    if(dir == North): return South
    if(dir == South): return North
```
complies correctly in actual Python, but it does not compile inside the game itself.  The single line **_if_**/**_return_** syntax results in an error stating that **"A code block must contain at least one statement."** This can be fixed by either moving the return statements to a new line with correct indentation, which expands what could be a one-liner into almost 10, or using a dictionary instead, which is what I have opted for, resulting in:

```
def reverse(dir):
    opposite = {West:East, East:West, North:South, South:North}
    return opposite[dir]
```

3) Unlike the planting phase, the sorting phase only reverses the horizontal direction(**_dir_**), but not the vertical one(**_vdir_**). This could still work is the size passed to "**_cactusProject(size)_**" matches the actual land size, but if it is smaller it results in incorrect behavior due to the drone leaving the **n*n** grid of the project and going into the rest of the farm, instead of warping back. If it goes over a grassland tile, it also causes an error as the **_measure()_** function returns **_None_**, which is then compared against the numerical value of its neighbor.